### PR TITLE
Fixed ExclusionNamespaces handling

### DIFF
--- a/cdmdotnet.Logging/PrimitiveLogger.cs
+++ b/cdmdotnet.Logging/PrimitiveLogger.cs
@@ -51,7 +51,7 @@ namespace cdmdotnet.Logging
 							try
 							{
 								bool found = false;
-								if (ExclusionNamespaces.Any(@namespace => !method.ReflectedType.FullName.StartsWith(@namespace)))
+								if (ExclusionNamespaces.All(@namespace => !method.ReflectedType.FullName.StartsWith(@namespace)))
 								{
 									container = string.Format("{0}.{1}", method.ReflectedType.FullName, method.Name);
 									found = true;


### PR DESCRIPTION
The original implementation stops filtering when there is more than one entry in the list.